### PR TITLE
Slightly speed up particle selection

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+use crate::vector::Vector;
 use crate::particle::{MovingParticle, StaticParticle};
 use std::slice;
 
@@ -160,5 +161,17 @@ where
         if particle.index < self.particles.len() {
             self.particles[particle.index] = particle.particle
         }
+    }
+}
+
+impl StaticParticleContainer {
+    pub fn select_for_binding(&self, target: &Vector, range: f64) ->  Vec<ParticleRef<StaticParticle>> {
+        // let result = Vec::<ParticleRef<StaticParticle>>::with_capacity(16);
+        self.values()
+            .filter(|ref_particle| {
+                (ref_particle.particle.pos.x - target.x).abs() <= range 
+                && (ref_particle.particle.pos.y - target.y).abs() <= range 
+            })
+            .collect()
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -265,7 +265,7 @@ impl Field {
         let bind_cfg = &self.bind_cfgs[0];
 
         'outer: for moving in self.mp_container.values() {
-            'inner: for fixed in self.sp_container.values() {
+            'inner: for fixed in self.sp_container.select_for_binding(&moving.particle.pos, bind_cfg.radius()) {
                 if let Some(binding) =
                     BindingResult::get_binding(moving.particle, fixed.particle, bind_cfg, bind_cfg)
                 {
@@ -287,7 +287,8 @@ impl Field {
 
         let closest_static_particles: Vec<_> = self
             .sp_container
-            .values()
+            .select_for_binding(&moving.pos, bind_cfg.radius())
+            .into_iter()
             .filter(|fixed| bind_cfg.close_enough_to_bind(&fixed.particle.pos, &moving.pos))
             .collect();
         if closest_static_particles.is_empty() {

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -162,6 +162,9 @@ impl BindingConfiguration {
     pub fn set_radius(&mut self, radius: f64) {
         self.radius = radius;
     }
+    pub fn radius(&self) -> f64 {
+        self.radius
+    }
 
     fn angle_to_port(&self, angle: f64) -> Option<usize> {
         let mut start = 0f64;


### PR DESCRIPTION
Use a prefilter to select local static particles for potential binding sites